### PR TITLE
Anleitung zur Migration von News Manager zu Neues

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ INSERT INTO rex_neues_entry
     (id, status, name, teaser, description, domain_ids, lang_id, publishdate, author_id, url, image, images, createdate, createuser, updatedate, updateuser)
 SELECT 
     pid,
-    IF(status=1, '1', '0'),
+    IF(status=1, '1', '-1'),
     title,
     subtitle,
     richtext,

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Wir danken Alex für die Bereitschaft, das Addon in die Hände von FriendsOfREDA
 | Autoren                              | ❌ nein                                      | ✅ `Aktuelles > Autoren`                                    |
 | Beiträge zeitgesteuert veröffentlichen | ❌ nein                                      | ✅ ja                                                     |
 | Mehrsprachigkeit                     | ✅ `News Manager > (Sprache auswählen)`      | ✅ `Aktuelles > Sprachen`                                   |
+| Eigene Felder hinzufügen             | ❌ nein                                      | ✅ ja (via YForm)                                           |
 | Dokumentation                        | ✅ als Plugin                                | ✅ `Aktuelles > Hilfe`                                      |
 | Einstellungen                        | ❌ nein                                      | ✅ `Aktuelles > Einstellungen`                              |
 | WYSIWYG-Editor                       | ✅ ausschließlich `redactor2`                | ✅ frei wählbar (`cke5`, `redactor`, `markitup`, `tinymce`) |

--- a/README.md
+++ b/README.md
@@ -16,29 +16,30 @@ Wir danken Alex für die Bereitschaft, das Addon in die Hände von FriendsOfREDA
 
 ### Funktions-Parität und Unterschiede
 
-Was | News Manager `3.0.3` | Neues `^4.0`
---- | --- | ---
-Letzte Weiterentwicklung und Wartung | ❌ 28. Dez. 2022 | ✅ aktuell
-REDAXO Core-Version | ab `^5.4` | ab `^5.15`
-PHP-Version | ab `^5.6` | ab `^7.2`
-Addon-Abhängigkeiten | URL ab `^2` | URL ab `^2`, YForm ab `^4`, YForm Field ab `^2`
-Position im Backend | `Addons > News Manager` | `Aktuelles` (oben)
-News-Übersicht | ✅ `News Manager > "News anlegen"` | ✅ `Aktuelles > Einträge`
-Kategorien | ✅ `News Manager > "Kategorien"` | ✅ `Aktuelles > Kategorien`
-Kommentare | ✅ als Plugin: `News Manager > "Kommentare"` | ❌ nein
-Autoren | ❌ nein | `Aktuelles > Autoren`
-Mehrsprachigkeit | ✅ `News Manager > (Sprache auswählen)` | ✅ `Aktuelles > Sprachen`
-Dokumentation | ✅ als Plugin | ✅ `Aktuelles > Hilfe`
-Einstellungen | ❌ nein | ✅ `Aktuelles > Einstellungen`
-WYSIWYG-Editor | ✅ ausschließlich `redactor2` | ✅ frei wählbar (`cke5`, `redactor`, `markitup`, `tinymce`)
-Backend-Sprachen | `de,en,es,se` | `de,en,es,se`
-RSS | ✅ ja | 🚧 in Arbeit
-Fertige Fragmente | ✅ ja | 🚧 in Arbeit
-Multi-Domain-Unterstützung | ❌ über Umwege | ✅ ja
-YOrm-Model | ❌ nein | ✅ ja (News-Einträge, Kategorien, Autoren, Sprachen)
-CSV-Import | ❌ nein | ✅ ja (via YForm)
-CSV-Export | ❌ nein | ✅ ja (via YForm)
-RESTful API | ❌ nein | ✅ ja (via YForm)
+| Was                                  | News Manager `3.0.3`                        | Neues `^4.0`                                               |
+| ------------------------------------ | ------------------------------------------- | ---------------------------------------------------------- |
+| Letzte Weiterentwicklung und Wartung | ❌ 28. Dez. 2022                             | ✅ aktuell                                                |
+| REDAXO Core-Version                  | ab `^5.4`                                    | ab `^5.15`                                                   |
+| PHP-Version                          | ab `^5.6`                                    | ab `^7.2`                                                    |
+| Addon-Abhängigkeiten                 | URL ab `^2`                                  | URL ab `^2`, YForm ab `^4`, YForm Field ab `^2`              |
+| Position im Backend                  | `Addons > News Manager`                      | `Aktuelles` (oben)                                           |
+| News-Übersicht                       | ✅ `News Manager > "News anlegen"`           | ✅ `Aktuelles > Einträge`                                   |
+| Kategorien                           | ✅ `News Manager > "Kategorien"`             | ✅ `Aktuelles > Kategorien`                                 |
+| Kommentare                           | ✅ als Plugin: `News Manager > "Kommentare"` | ❌ nein                                                     |
+| Autoren                              | ❌ nein                                      | ✅ `Aktuelles > Autoren`                                    |
+| Beiträge zeitgesteuert veröffentlichen | ❌ nein                                      | ✅ ja                                                     |
+| Mehrsprachigkeit                     | ✅ `News Manager > (Sprache auswählen)`      | ✅ `Aktuelles > Sprachen`                                   |
+| Dokumentation                        | ✅ als Plugin                                | ✅ `Aktuelles > Hilfe`                                      |
+| Einstellungen                        | ❌ nein                                      | ✅ `Aktuelles > Einstellungen`                              |
+| WYSIWYG-Editor                       | ✅ ausschließlich `redactor2`                | ✅ frei wählbar (`cke5`, `redactor`, `markitup`, `tinymce`) |
+| Backend-Sprachen                     | ✅`de,en,es,se`                              | ✅ `de,en,es,se,fr,it`                                      |
+| RSS                                  | ✅ ja                                        | 🚧 in Arbeit                                               |
+| Fertige Fragmente                    | ✅ ja                                        | 🚧 in Arbeit                                               |
+| Multi-Domain-Unterstützung           | ❌ über Umwege                               | ✅ ja                                                       |
+| YOrm-Model                           | ❌ nein                                      | ✅ ja (News-Einträge, Kategorien, Autoren, Sprachen)        |
+| CSV-Import                           | ❌ nein                                      | ✅ ja (via YForm)                                           |
+| CSV-Export                           | ❌ nein                                      | ✅ ja (via YForm)                                           |
+| RESTful API                          | ❌ nein                                      | ✅ ja (via YForm)                                           |
 
 ### Automatische Daten-Migration von News Manager zu Neues 4
 

--- a/README.md
+++ b/README.md
@@ -1,143 +1,108 @@
-News-Manager
-============
+# News-Manager
+
+> Der News-Manager wird nicht mehr weiterentwickelt. Nutze stattdessen das Nachfolge-Addon [Neues für REDAXO 5](https://github.com/friendsofredaxo/neues/).
+
+## Migration von News-Manager zu Neues
+
+### Warum der Wechsel?
+
+Das FOR-Addon News-Manager befindet sich nicht mehr in aktiver Entwicklung. Es wurde nur noch bis Ende 2022 gewartet. Potentielle Sicherheitslücken werden nicht mehr geschlossen.
+
+Um die Lücke zu schließen, wird das Addon `Neues` von @alexplus_de zu FriendsOfREDAXO gespendet. Die Weiterentwicklung des Neues ist gesichert. Es wird ständig an die neuesten REDAXO-Versionen angepasst und erweitert.
+
+Ein wesentlicher Vorteil gegenüber dem News Manager ist die Unterstützung von YForm. Damit lassen sich die News-Einträge und Kategorien komfortabel verwalten und erweitern, viele Funktionen von YForm und YOrm können genutzt werden.
+
+Wir danken Alex für die Bereitschaft, das Addon in die Hände von FriendsOfREDAXO zu geben, Alex bleibt Projekt-Lead des Addons. Sowie @schorschy @skerbis und @eace für die Unterstützung bei der Entwicklung.
+
+### Funktions-Parität und Unterschiede
+
+Was | News Manager `3.0.3` | Neues `^4.0`
+--- | --- | ---
+Letzte Weiterentwicklung und Wartung | ❌ 28. Dez. 2022 | ✅ aktuell
+REDAXO Core-Version | ab `^5.4` | ab `^5.15`
+PHP-Version | ab `^5.6` | ab `^7.2`
+Addon-Abhängigkeiten | URL ab `^2` | URL ab `^2`, YForm ab `^4`, YForm Field ab `^2`
+Position im Backend | `Addons > News Manager` | `Aktuelles` (oben)
+News-Übersicht | ✅ `News Manager > "News anlegen"` | ✅ `Aktuelles > Einträge`
+Kategorien | ✅ `News Manager > "Kategorien"` | ✅ `Aktuelles > Kategorien`
+Kommentare | ✅ als Plugin: `News Manager > "Kommentare"` | ❌ nein
+Autoren | ❌ nein | `Aktuelles > Autoren`
+Mehrsprachigkeit | ✅ `News Manager > (Sprache auswählen)` | ✅ `Aktuelles > Sprachen`
+Dokumentation | ✅ als Plugin | ✅ `Aktuelles > Hilfe`
+Einstellungen | ❌ nein | ✅ `Aktuelles > Einstellungen`
+WYSIWYG-Editor | ✅ ausschließlich `redactor2` | ✅ frei wählbar (`cke5`, `redactor`, `markitup`, `tinymce`)
+Backend-Sprachen | `de,en,es,se` | `de,en,es,se`
+RSS | ✅ ja | 🚧 in Arbeit
+Fertige Fragmente | ✅ ja | 🚧 in Arbeit
+Multi-Domain-Unterstützung | ❌ über Umwege | ✅ ja
+YOrm-Model | ❌ nein | ✅ ja (News-Einträge, Kategorien, Autoren, Sprachen)
+CSV-Import | ❌ nein | ✅ ja (via YForm)
+CSV-Export | ❌ nein | ✅ ja (via YForm)
+RESTful API | ❌ nein | ✅ ja (via YForm)
+
+### Automatische Daten-Migration von News Manager zu Neues 4
+
+Es gibt einen eine automatische Migration von News Manager-Einträgen zu Neues 4.
+
+Diese werden bei Installation dieser finalen Version des News Managers ausgeführt. Alternativ müssen folgenden Schritte erfolgen:
+
+### Manuelle Daten-Migration von News Manager zu Neues 4
+
+1. Backup der Datenbank und des Dateisystems
+2. `Neues` installieren (`YForm`, `YForm Field`, `URL` müssen bereits installiert und aktiviert sein)
+3. Bestehende News-Einträge und Kategorien in Neues importieren
+4. Module, Templates und URL-Profile anpassen
+5. `News Manager` deinstallieren.
+
+#### SQL-Befehle zur Migration der Daten
+
+> Hinweis: Die Autoren müssen manuell oder mit eigenen Anpassungen übertragen werden, da es hierfür eine eigene Tabelle gibt.
+
+```SQL
+INSERT INTO rex_neues_category
+    (id, name, image, status, createuser, createdate, updateuser, updatedate)
+SELECT 
+    pid,
+    name,
+    '',
+    '1', 
+    createuser,
+    createdate,
+    updateuser,
+    updatedate
+FROM rex_newsmanager_categories;
+
+INSERT INTO rex_neues_entry
+    (id, status, name, teaser, description, domain_ids, lang_id, publishdate, author_id, url, image, images, createdate, createuser, updatedate, updateuser)
+SELECT 
+    pid,
+    IF(status=1, '1', '0'),
+    title,
+    subtitle,
+    richtext,
+    '',
+    clang_id,
+    createdate,
+    0,
+    seo_canonical,
+    '',
+    images,
+    createdate,
+    createuser,
+    updatedate,
+    updateuser
+FROM rex_newsmanager;
+
+INSERT INTO rex_neues_entry_category_rel (entry_id, category_id)
+SELECT rex_newsmanager.pid , rex_newsmanager_categories.id
+FROM rex_newsmanager
+INNER JOIN rex_newsmanager_categories
+ON FIND_IN_SET(rex_newsmanager_categories.id, REPLACE(REPLACE(rex_newsmanager.newsmanager_category_id, '|', ','), ' ', '')) > 0;
+```
 
 ![Screenshot](https://raw.githubusercontent.com/FriendsOfREDAXO/newsmanager/assets/screenshot.png)
 
 Dieses AddOn stellt eine einfache Newsverwaltung bereit. Dabei werden die Beiträge in einer eigenen Tabelle abgelegt.
-
-## Beschreibung
-
-Die Kernfunktion ist die Verwaltung von Newsartikeln. Man kann Kategorien festlegen und die Artikel dann einer oder mehreren Kategorien zuordenen.
-
-Für eine einfache Ausgabe der Artikel und Artikellisten sind einige Funktionen vorhanden. Man kann aber die Ausgabe auch über Datenbankabfragen realisieren.
-
-Alle zukünftige Funktionen werden über Plugins eingebunden. Das erste Plugin realisiert eine Kommentarfunktioalität.
-
-**Derzeitige Funktionen:**
-
-* Kategorien
-* Mehrsprachigkeit
-* RSS Feed
-* Kommentare (via Plugin)
-
-### Installation
-
-Einfach das AddOn nach `/redaxo/src/addons/` kopieren und im AddOns-Bereich installieren.
-
-**Das AddOn benötigt folgende AddOns:**
-
-* [redaxo_url V.2](https://github.com/tbaddade/redaxo_url) (für "sprechende" URLs)
-* [redactor2](https://github.com/FriendsOfREDAXO/redactor2) (optional, macht aber Sinn wenn man Richtext im Artikel verwenden will).
-
-Das AddOn enthält eine Einstellungsseite. Hier sollten Sie die Kategorie auswählen, in welcher im Startartikel die Artikelliste und die Artikelansicht ausgegben wird. Beim Klick auf "Einstellungen speichern" wird (falls vorhanden) ein Profil für das redactor2-AddOn sowie die Einstellungen für das url-AddOn angelegt.
-
-### Template anpassen
-
-Man kann natürlich einfach eine entsprechende Datenbank Abfrage machen und sich selbst um die Ausgabe kümmern. Wie das geht, kann man in der REDAXO Doku nachlesen.
-
-Es gibt aber auch Funktionen, die sich um die Ausgabe kümmern. Hier ein paar Beispiele für die Verwendung dieser Klassenfunktionen (Listen- und Singleansicht in einem einzigen Template):
-
-
-**Headerbereich:**
-
-```php
-$newsmanager = new NewsManager();
-
-// Mit aktiviertem Kommentarplugin:
-// $newsmanager = new NewsManagerWithComments();
-
-// Laden des JS falls mit Kommentarfuntion (and Ende des <head>)
-<?php
- if ((rex_plugin::get('newsmanager', 'comments')->isAvailable()) && (get_class($newsmanager) == 'NewsManagerWithComments')) {
-   echo $newsmanager->getCommentJavaScript();             
- }
-?>
-
-// ---------------------------
-
-
-$news_id = $newsmanager->getNewsIdParameter();
-
-if ($news_id) {
-
-    // Artikel-Ansicht
-
-    $article_post = $newsmanager->getArticleById($news_id);
-
-    echo $article_post->getSEOTitleTag();
-    echo $article_post->getDescriptionTag();
-    echo $article_post->getCanonicalUrlTag($this->getValue('article_id'));
-    echo $article_post->getHrefLangTag ($article_post->getId());
-
-} else {
-
-    // Artikel-Listenansicht
-
-    $seo = new rex_yrewrite_seo();
-
-    echo $seo->getTitleTag();
-    echo $seo->getDescriptionTag();
-    echo $seo->getRobotsTag();
-    echo $seo->getHreflangTags();
-    echo $seo->getCanonicalUrlTag();
-
-}
-```
-
-RSS Link (falls gewünscht):
-
-```php
-echo $newsmanager->getRssHeaderLink();
-```
-
-**Artikel-Ansicht und Artikel-Listenansicht**
-
-```php
-if ($news_id) {
-
-    // Artikel-Ansicht
-    
-    echo $newsmanager->printSingleView($article_post);
-    // Mit aktiviertem Kommentarplugin:
-    // echo $newsmanager->getCommentList($article_post->getPid());
-    // echo $newsmanager->getCommentForm($article_post->getPid());
-
-} else {
-
-    // Artikel-Listenansicht
-    
-    echo '  <h1>' . $this->getValue("name") . '</h1>';
-    
-    // Ausgabe 10 Artikel, alle weiteren paginiert
-    
-    echo $newsmanager->printListView($this->getValue('article_id'), 10);
-
-}
-```
-
-**Kategorie Menü**
-
-```php
-echo $newsmanager->printCategoryMenu();
-```
-
-### Ausgabe anpassen
-
-Den Quellcode für die Ausgabe kann man auch anpassen.
-Es gibt dafür sog. Views, also HTML/PHP Schnipsel die in `/redaxo/data/addons/newsmanager/views/` bzw. für die Kommentare
-unter `/redaxo/data/addons/newsmanager/views/comments/views/` abgelegt sind.
-
-**Ausgabe als Modul**
-
-Zum Beispiel Teaser der letzten drei Artikel:
-
-```php
-// Ausgabe der Newsartikel
-$newsmanager = '';
-$newsmanager = new NewsManager();
-// Listenansicht
-echo $newsmanager->printTeaserListView($this->getValue('article_id'), 3);
-```
 
 ## Lizenz
 
@@ -147,9 +112,5 @@ siehe [LICENSE](https://github.com/FriendsOfREDAXO/newsmanager/blob/master/LICEN
 
 **Friends Of REDAXO**
 
-* https://www.redaxo.org
-* https://github.com/FriendsOfREDAXO
-
-**Projekt-Lead**
-
-[Tizian Bauer](https://github.com/ansichtsache)
+* <https://www.redaxo.org>
+* <https://github.com/FriendsOfREDAXO>

--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,39 @@
+INSERT INTO rex_neues_category
+    (id, name, image, status, createuser, createdate, updateuser, updatedate)
+SELECT 
+    pid,
+    name,
+    '',
+    '1', 
+    createuser,
+    createdate,
+    updateuser,
+    updatedate
+FROM rex_newsmanager_categories;
+
+INSERT INTO rex_neues_entry
+    (id, status, name, teaser, description, domain_ids, lang_id, publishdate, author_id, url, image, images, createdate, createuser, updatedate, updateuser)
+SELECT 
+    pid,
+    IF(status=1, '1', '0'),
+    title,
+    subtitle,
+    richtext,
+    '',
+    clang_id,
+    createdate,
+    0,
+    seo_canonical,
+    '',
+    images,
+    createdate,
+    createuser,
+    updatedate,
+    updateuser
+FROM rex_newsmanager;
+
+INSERT INTO rex_neues_entry_category_rel (entry_id, category_id)
+SELECT rex_newsmanager.pid , rex_newsmanager_categories.id
+FROM rex_newsmanager
+INNER JOIN rex_newsmanager_categories
+ON FIND_IN_SET(rex_newsmanager_categories.id, REPLACE(REPLACE(rex_newsmanager.newsmanager_category_id, '|', ','), ' ', '')) > 0;

--- a/migration.sql
+++ b/migration.sql
@@ -15,7 +15,7 @@ INSERT INTO rex_neues_entry
     (id, status, name, teaser, description, domain_ids, lang_id, publishdate, author_id, url, image, images, createdate, createuser, updatedate, updateuser)
 SELECT 
     pid,
-    IF(status=1, '1', '0'),
+    IF(status=1, '1', '-1'),
     title,
     subtitle,
     richtext,

--- a/package.yml
+++ b/package.yml
@@ -23,6 +23,7 @@ requires:
 conflicts:
     packages:
         url: '<=2.0.0'
+        neues: '<4.0.1'
 installer_ignore:
   - .git
   - .github

--- a/package.yml
+++ b/package.yml
@@ -1,7 +1,5 @@
-# Alle hier gesetzten Werte können über $addon->getProperty($key) abgefragt werden
-
 package: newsmanager 
-version: '3.0.3'
+version: '3.1.0'
 author: Friends Of REDAXO 
 supportpage: https://github.com/FriendsOfREDAXO/newsmanager/
 
@@ -15,11 +13,13 @@ page:
         settings: { perm: 'newsmanagersettings[]', title: 'translate:settings', icon: rex-icon fa-wrench }
 
 requires:
-    redaxo: '^5.4' # benötigt mindestens REDAXO 5.4
+    redaxo: '^5.15'
     packages:
-        url: '>1.0.0' # benötig Addon redaxo_url V.2
+        neues: '^4'
+        url: '^2'
+        yform: '^4'
     php:
-        version: '>=5.6' # benötigt mindestens PHP 5.6
+        version: '>=7.3'
 conflicts:
     packages:
         url: '<=2.0.0'

--- a/update.php
+++ b/update.php
@@ -31,3 +31,7 @@ rex_sql_table::get(rex::getTable('newsmanager_categories'))
     ->ensureColumn(new rex_sql_column('updatedate', 'datetime'))
     ->setPrimaryKey('pid')
     ->ensure();
+
+/* Migrate data from newsmanager to friendsofredaxo\neues */
+$query = rex_file::get(rex_path::addon('newsmanager', 'migration.sql'));
+rex_sql::factory()->setQuery($query);


### PR DESCRIPTION
Erstellt eine finale Version 3.1.0 des News Managers, die sich nur in Kombination mit `neues` installieren lässt.

Beim Update werden alle Daten des News Managers (Einträge und Kategorien mit Ausnahme der Autoren) in die Struktur von Neues migriert.

Eine umfangreiche Anleitung und Feature-Vergleich helfen bei der Entscheidung. Beim Release sollten diese Informationen ebenfalls in die Release Notes, um im Installer darüber zu informieren. 

Voraussetzungen
- [x] Neues wurde bereits zu FOR migriert
- [x] Issues bei Neues in Bezug auf den News Manager wurden bereits gelöst